### PR TITLE
Define STRICT_R_HEADERS in Makevars*, use M_PI in two files

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,4 @@
 ## Use the R_HOME indirection to support installations of multiple R version
 
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = `$(R_HOME)/bin/Rscript -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) -DSTRICT_R_HEADERS
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,3 +1,3 @@
 ## Use the R_HOME indirection to support installations of multiple R version
-PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS)
-PKG_LIBS = `$(R_HOME)/bin/Rscript.exe -e "Rcpp:::LdFlags()"` $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)
+PKG_CXXFLAGS = $(SHLIB_OPENMP_CXXFLAGS) -DSTRICT_R_HEADERS
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS) $(SHLIB_OPENMP_CXXFLAGS)

--- a/src/calcLB.cpp
+++ b/src/calcLB.cpp
@@ -83,7 +83,7 @@ double calcLB (const arma::mat &y,
     // Ideal Points
     double elpx = (0
                    // -std::log(nN) // WRONG
-                   -(nN * nD) * std::log(2 * PI) / 2
+                   -(nN * nD) * std::log(2 * M_PI) / 2
                    -(nN / 2) * std::log(arma::det(xsigma))
                    ) ;
     {
@@ -102,7 +102,7 @@ double calcLB (const arma::mat &y,
     // Bill Parameters
     double elpb2 = (0
                     // -std::log(nJ) // WRONG
-                    -(nJ * (nD + 1)) * std::log(2 * PI) / 2
+                    -(nJ * (nD + 1)) * std::log(2 * M_PI) / 2
                     -(nJ / 2) * std::log(arma::det(betasigma))
                     ) ;
     {
@@ -130,7 +130,7 @@ double calcLB (const arma::mat &y,
     // Augmented Likelihood
     double elpystar = (0
                        // -std::log(nN * nJ) // WRONG
-                       -((nN * nJ) / 2) * std::log(2 * PI)
+                       -((nN * nJ) / 2) * std::log(2 * M_PI)
                        ) ;
     {
 #pragma omp parallel for reduction(+:elpystar)

--- a/src/enttn1.cpp
+++ b/src/enttn1.cpp
@@ -39,7 +39,7 @@ double enttn1(const double mean,
 
     double num = num1 - num2 ;
     double denom = 2 * q3 ;
-    double temp = (.5 * log(2 * PI * exp(1.0)) +
+    double temp = (.5 * log(2 * M_PI * exp(1.0)) +
                    log(sd * q3)
                    ) ;
 


### PR DESCRIPTION
Dear Kosuke, dear emIRT team,

Your CRAN package emIRT uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at
  https://github.com/RcppCore/Rcpp/issues/1158
and the links therein for more context on this.

Here, instead of prefixing each #include <Rcpp.h> with STRICT_R_HEADERS I changed src/Makevars* to define it which is less invasive still ensures we will not get surprised later. The actual change that is needed is the change from PI to M_PI in two files. (And while looking at src/Makevars* I removed the old link instruction for Rcpp we have not needed anymore since around 2013.)

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by
  https://github.com/RcppCore/Rcpp/issues/1158
to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.